### PR TITLE
Csm serialization: make PeptideMonoisotopicMass part of

### DIFF
--- a/EngineLayer/CrosslinkSearch/CrosslinkSpectralMatch.h
+++ b/EngineLayer/CrosslinkSearch/CrosslinkSpectralMatch.h
@@ -111,20 +111,24 @@ namespace EngineLayer
             /// count:       IN how many elements to unpack.  -1 indicates until end of buffer is reached
             /// len:         OUT number of bytes used for unpacking 'count' elements
             /// newCsmVec:   OUT (vector of) new CrosslinkSpectralMatch(s) .
+            /// mods:        IN unordered_map of mods applied to Protein. Required to reconstruct a Csm
             /// ms2Scans:    IN vector of Ms2Scans. Required to reconstruct a Csm
             /// proteinList: IN vector of Protein*. Required to reconstruct a Csm
             /// </summary>
             static void Unpack ( char *buf, size_t buf_size, int count, size_t &len, 
                                  std::vector<CrosslinkSpectralMatch *> &newCsmVec,
+                                 const std::vector<Modification*> &mods,
                                  const std::vector<Ms2ScanWithSpecificMass*> &ms2Scans,
                                  const std::vector<Protein*> &proteinList );
             static void Unpack ( char *buf, size_t buf_size, size_t &len,
                                  CrosslinkSpectralMatch **newCsm,
+                                 const std::vector<Modification*> &mods,
                                  const std::vector<Ms2ScanWithSpecificMass*> &ms2Scans,
                                  const std::vector<Protein *> &proteinList );
 
             static void Unpack_internal ( std::vector<char *> &input, int &index, size_t &len,
                                           CrosslinkSpectralMatch** newCsm,
+                                          const std::vector<Modification*> &mods,
                                           const std::vector<Ms2ScanWithSpecificMass*> &ms2Scans,
                                           const std::vector<Protein* > &proteinList,
                                           bool &has_beta_peptide);

--- a/Test/CsmSerializationTest.cpp
+++ b/Test/CsmSerializationTest.cpp
@@ -88,8 +88,8 @@ int main ( int argc, char **argv )
     //Chemistry::PeriodicTable::Load (elr);
     UsefulProteomicsDatabases::PeriodicTableLoader::Load (elr);
 
-    //std::cout << ++i << ". CSMSerialization_BSA_DSSO" << std::endl;
-    //Test::CSMSerializationTest::CSMSerializationTest_BSA_DSSO();
+    std::cout << ++i << ". CSMSerialization_BSA_DSSO" << std::endl;
+    Test::CSMSerializationTest::CSMSerializationTest_BSA_DSSO();
 
     std::cout << ++i << ". TestDeadendTrisSerialized" << std::endl;
     Test::CSMSerializationTest::TestDeadendTrisSerialized();
@@ -215,9 +215,11 @@ namespace Test
 
         if ( ret > 0 ) {
             std::vector<CrosslinkSpectralMatch*> unpackedPsms;
+            std::vector<Modification*> modList;
             int count=-1;
             size_t len=0;
-            CrosslinkSpectralMatch::Unpack( sbuf, bufsize, count, len, unpackedPsms, listOfSortedms2Scans, proteinList);
+            CrosslinkSpectralMatch::Unpack( sbuf, bufsize, count, len, unpackedPsms,
+                                            modList, listOfSortedms2Scans, proteinList);
 
             output.open("CsmSerialized.out");
             for ( auto psms : unpackedPsms ) {
@@ -328,7 +330,7 @@ namespace Test
             std::vector<CrosslinkSpectralMatch*> unpackedPsms;
             int count=-1;
             size_t len=0;
-            CrosslinkSpectralMatch::Unpack( sbuf, bufsize, count, len, unpackedPsms, scans, pvec);
+            CrosslinkSpectralMatch::Unpack( sbuf, bufsize, count, len, unpackedPsms, vec2, scans, pvec);
 
             Assert::AreEqual(csms.size(), unpackedPsms.size());
             CrosslinkSpectralMatch *csm2 = unpackedPsms.front();


### PR DESCRIPTION
Serialization information and set explicitly after the
ResolveAllAmbiguity() function. For Csm's that contained modifications
I have not found yet a generic solution on how to otherwise
determine the correct value. Might have to revisit later, this is
really just a hack at this point.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>