### PR TITLE
Program.cpp: ensure that only process 0 is verbose

### DIFF
--- a/CMD/Program.cpp
+++ b/CMD/Program.cpp
@@ -103,6 +103,11 @@ int main( int argc, char *argv[] )
     }
     
     int verbosity=1; // Setting the default to provide Status updates
+    if ( rank > 0 ) {
+        // for MPI executions, only rank 0 will provide status updates.
+        verbosity = 0;
+    }
+
     int opt=0;
     static struct option long_options[] = {
         {"tasks", required_argument, 0, 't'},


### PR DESCRIPTION
to keep the output more readable.

Signed-off-by: Edgar Gabriel <egabriel@central.uh.edu>